### PR TITLE
More robust positioning and sizing.

### DIFF
--- a/src/docs/main.css
+++ b/src/docs/main.css
@@ -1,2 +1,10 @@
 @import "../../node_modules/bootstrap/dist/css/bootstrap.css";
 @import "../../node_modules/highlight.js/styles/zenburn.css";
+
+body {
+  background-color: #f4f6f8;
+}
+
+#textarea {
+  background-color: #FAFAFA;
+}


### PR DESCRIPTION
1. Instead of wrapping the textarea, use absolutely-positioned backdrop and overlay divs inserted as siblings to the textarea.
2. Account for the scrollbar when sizing the overlay.

The only `style` of the textarea we need to modify now is `background`.
Also the textarea is no longer moved in the DOM.

Fixes #14 #15 #16